### PR TITLE
Exclude translation files from Prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+src/features/translations/**/*


### PR DESCRIPTION
This way, we can just use the JSONs coming in from Phrase as-is without Prettier mucking around in them.