### PR TITLE
(update) prefers-color-scheme head meta

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,8 +6,14 @@
         <meta charset="utf-8" />
         <meta name="msapplication-TileColor" content="#ffffff" />
         <meta name="msapplication-config" content="https://cdn.rio.cloud/images/favicon/browserconfig.xml" />
-        <meta name="theme-color" content="#ffffff" />
-        <meta name="apple-mobile-web-app-capable" content="yes" />
+
+        <meta name='theme-color' content='#ffffff' media='(prefers-color-scheme: light)' />
+        <meta name='theme-color' content='#000000' media='(prefers-color-scheme: dark)' />
+
+        <meta name='apple-mobile-web-app-capable' content='yes' />
+        <meta name='apple-mobile-web-app-status-bar-style' content='#ffffff' media='(prefers-color-scheme: light)' />
+        <meta name='apple-mobile-web-app-status-bar-style' content='#000000' media='(prefers-color-scheme: dark)' />
+
         <meta name="format-detection" content="telephone=no" />
         <meta http-equiv="content-encoding" content="gzip" />
 


### PR DESCRIPTION
make theme-color and apple-mobile-web-app-status-bar-style darkmode ready